### PR TITLE
This fixes issue #3 for good.  Should have no consequences either.

### DIFF
--- a/src/Kopernicus/Components/KopernicusStar.cs
+++ b/src/Kopernicus/Components/KopernicusStar.cs
@@ -283,7 +283,7 @@ namespace Kopernicus.Components
             // Get Thermal Stats
             if (vessel.mainBody.atmosphere)
             {
-                if (sun == GetBodyReferencing(vessel.mainBody))
+                if (sun == GetBodyReferencing(vessel.mainBody) && !vessel.mainBody.isStar)
                 {
                     FlightIntegrator FI = vessel.GetComponent<FlightIntegrator>();
                     vessel.mainBody.GetAtmoThermalStats(true, sun, sunVector, Vector3d.Dot(sunVector, vessel.upAxis), vessel.upAxis, vessel.altitude, out FI.atmosphereTemperatureOffset, out FI.bodyEmissiveFlux, out FI.bodyAlbedoFlux);
@@ -358,7 +358,7 @@ namespace Kopernicus.Components
         /// </summary>
         public static CelestialBody GetBodyReferencing(CelestialBody body)
         {
-            while (body?.orbit?.referenceBody != null && !body.orbit.referenceBody.isStar)
+            while (body?.orbit?.referenceBody != null)
             {
                 body = body.orbit.referenceBody;
             }

--- a/src/Kopernicus/Components/KopernicusStar.cs
+++ b/src/Kopernicus/Components/KopernicusStar.cs
@@ -281,7 +281,7 @@ namespace Kopernicus.Components
             Ray ray = new Ray(ScaledSpace.LocalToScaledSpace(integratorPosition), sunVector);
 
             // Get Thermal Stats
-            if (vessel.mainBody.atmosphere && !vessel.mainBody.isStar)
+            if (vessel.mainBody.atmosphere)
             {
                 if (sun == GetBodyReferencing(vessel.mainBody))
                 {


### PR DESCRIPTION
This simple change should be the answer to the longstanding atmospheric bug.  As it turns out, bodies orbit stars too, so why did we decide to eliminate them in this check?  It literally prevented the atmospheric temp code from finding the Sun.  Lol.