### PR TITLE
Revert "Sha hash release building fix"

### DIFF
--- a/src/Kopernicus/Injector.cs
+++ b/src/Kopernicus/Injector.cs
@@ -46,7 +46,7 @@ namespace Kopernicus
 
         // The checksum of the System.cfg file.
         [SuppressMessage("ReSharper", "UnusedMember.Local")]
-        private const String CONFIG_CHECKSUM = "40fb46640437a7c297a4c0df27d7addc5d2a8f3998a014f6ccb3941fc1949d2b";
+        private const String CONFIG_CHECKSUM = "73eb1037678bc520a0fe2e89768e0549b36f17a9cac7136af6e3e6b7a0ccf9b9";
 
         // Backup of the old system prefab, in case someone deletes planet templates we need at Runtime (Kittopia)
         public static PSystem StockSystemPrefab { get; private set; }


### PR DESCRIPTION
Reverts prestja/Kopernicus#11, this was an unneccesary fix based on changed newline endings in my branch.