### PR TITLE
Fix shadow issue with gas giants

### DIFF
--- a/src/Kopernicus/Configuration/Body.cs
+++ b/src/Kopernicus/Configuration/Body.cs
@@ -358,6 +358,8 @@ namespace Kopernicus.Configuration
                 // Create the scaled version
                 GeneratedBody.scaledVersion = new GameObject(Name) {layer = GameLayers.SCALED_SPACE};
                 GeneratedBody.scaledVersion.transform.parent = Utility.Deactivator;
+                //Create a reference geosphere.
+                GeneratedBody.scaledVersion.AddOrGetComponent<MeshFilter>().sharedMesh = Templates.ReferenceGeosphere;
             }
 
             // Create accessors


### PR DESCRIPTION
Borrowing a ton of (well tested) gas giant detection code from my 1.10 branch, this basically selects only non-Jool gas giants and forces them to use the proper mesh for their shadows (the Joolian one borrowed in Templates.cs).  Works in limited testing, perhaps wait a day or two for reports to merge.

As for why it's needed?  Dunno, for some reason gas giants not templated as Jool don't get assigned a mesh and I can't figure out why.  This kludge just makes sure they all get a mesh.